### PR TITLE
Cache data based on request type

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,14 @@ module.exports = {
 		});
 	},
 
+	// Use renderType from query params to differentiate cache keys (otherwise we return the same content for different render types)
+	getCacheKey: function(req) {
+		return req.prerender.url + '-' + (req.query.renderType || 'default');
+	},
+
 	requestReceived: function(req, res, next) {
-		this.cache.get(req.prerender.url, function (err, result) {
+		var key = this.getCacheKey(req);
+		this.cache.get(key, function (err, result) {
 			if (!err && result) {
 				req.prerender.cacheHit = true;
 				res.send(200, result);
@@ -20,7 +26,8 @@ module.exports = {
 
 	beforeSend: function(req, res, next) {
 		if (!req.prerender.cacheHit && req.prerender.statusCode == 200) {
-			this.cache.set(req.prerender.url, req.prerender.content);
+			var key = this.getCacheKey(req);
+			this.cache.set(key, req.prerender.content);
 		}
 		next();
 	}


### PR DESCRIPTION
This fixes a bug where if you are utilize the caching plugin and attempt to request a specific renderType, subsequent requests for that URL with a different renderType will result in the binary data of the previous request being returned with the requested data type headers of the new request.

For example, this bug's behavior currently:
1. request a page with renderType=png, prerender returns and caches a png of the URL
2. request the same page with renderType=html, prerender returns png binary data with header data type of html

This PR resolves the above behavior by saving the renderType with the cached data.